### PR TITLE
fix: surface parsing errors and loosen regex

### DIFF
--- a/_extensions/marimo/extract.py
+++ b/_extensions/marimo/extract.py
@@ -19,6 +19,7 @@ import os
 import re
 import sys
 from collections.abc import Callable
+from dataclasses import dataclass
 from textwrap import dedent
 from typing import Any, ClassVar, Optional
 from urllib.parse import quote
@@ -48,6 +49,19 @@ from marimo._islands import MarimoIslandStub
 
 SafeWrap = SafeWrapGeneric[App]
 
+
+@dataclass(frozen=True, slots=True)
+class _ParseError:
+    """Sentinel for a cell whose source couldn't be added to the app.
+
+    Surfaces parse-time exceptions (e.g. `SyntaxError`) that would otherwise be
+    swallowed by the broad except around `app.add_code` and rendered as empty
+    HTML, leaving the reader no clue that a cell was dropped. (Linear MO-6287.)
+    """
+
+    message: str
+
+
 __version__ = "0.4.5"
 
 # See https://quarto.org/docs/computations/execution-options.html
@@ -62,8 +76,13 @@ default_config = {
     "editor": False,
 }
 
+# Rewrite md-form SQL fences (both dot-joined and class-with-space) to the
+# qmd-form `sql {.marimo ...}` shape that marimo's parser classifies as
+# language="sql". Without this both `{sql.marimo}` and `{sql .marimo}` are
+# parsed as language="python", drop into `app.add_code` as raw SQL, and emit
+# empty cells. (Linear MO-6285.)
 SQL_DOT_FENCE_REGEX = re.compile(
-    r"^(\s*`{3,})\s*\{\s*sql\.marimo(?P<attrs>[^}]*)\}\s*$",
+    r"^(\s*`{3,})\s*\{\s*sql\s*\.marimo(?P<attrs>[^}]*)\}\s*$",
     re.MULTILINE,
 )
 DEFAULT_SQL_QUERY_TARGET = "_df"
@@ -116,7 +135,7 @@ def extract_and_strip_quarto_config(block: str) -> tuple[dict[str, Any], str]:
 
 def get_mime_render(
     global_options: dict[str, Any],
-    stub: Optional[MarimoIslandStub],
+    stub: Optional[MarimoIslandStub | _ParseError],
     config: dict[str, bool],
     mime_sensitive: bool,
 ) -> dict[str, Any]:
@@ -131,6 +150,16 @@ def get_mime_render(
     config = {**global_options, **config}
     if not config["include"] or stub is None:
         return {"type": "html", "value": ""}
+
+    if isinstance(stub, _ParseError):
+        if not config["error"]:
+            return {"type": "html", "value": ""}
+        if mime_sensitive:
+            return {"type": "blockquote", "value": stub.message}
+        return {
+            "type": "html",
+            "value": f'<pre class="marimo-error">{stub.message}</pre>',
+        }
 
     eval_enabled = config["eval"]
     show_output = config["output"] and eval_enabled
@@ -310,7 +339,9 @@ def build_export_with_mime_context(
         app = MarimoIslandGenerator()
 
         has_attrs: bool = False
-        stubs: list[tuple[dict[str, bool], Optional[MarimoIslandStub]]] = []
+        stubs: list[
+            tuple[dict[str, bool], Optional[MarimoIslandStub | _ParseError]]
+        ] = []
         for child in root:
             # only process code cells
             if child.tag == MARIMO_MD:
@@ -338,8 +369,10 @@ def build_export_with_mime_context(
                     code,
                     is_raw=True,
                 )
-            except Exception:  # noqa: BLE001
-                stubs.append((config, None))
+            except Exception as exc:  # noqa: BLE001
+                msg = f"{type(exc).__name__}: {exc}"
+                sys.stderr.write(f"marimo: failed to parse cell: {msg}\n")
+                stubs.append((config, _ParseError(msg)))
                 continue
 
             assert isinstance(stub, MarimoIslandStub), "Unexpected error, please report"

--- a/src/marimo-engine.ts
+++ b/src/marimo-engine.ts
@@ -156,15 +156,15 @@ const marimoEngineDiscovery: ExecutionEngineDiscovery = {
   },
 
   claimsLanguage: (language: string, firstClass?: string): boolean | number => {
-    // Claim {python .marimo} with priority 2 (overrides Jupyter's fallback)
-    if (language === "python" && firstClass === "marimo") {
+    // Claim {python .marimo} / {sql .marimo} with priority 2 (overrides Jupyter/sql fallback)
+    if ((language === "python" || language === "sql") && firstClass === "marimo") {
       return 2;
     }
-    // Claim {python.marimo} with priority 1 (no competition for this language)
-    if (language === "python.marimo") {
+    // Claim {python.marimo} / {sql.marimo} with priority 1 (no competition for this language)
+    if (language === "python.marimo" || language === "sql.marimo") {
       return 1;
     }
-    return false; // Don't claim other python blocks
+    return false; // Don't claim other python/sql blocks
   },
 
   canFreeze: false,

--- a/tests/python/test_extract.py
+++ b/tests/python/test_extract.py
@@ -6,6 +6,7 @@ from urllib.parse import unquote
 from xml.etree.ElementTree import Element
 
 from _extensions.marimo.extract import (
+    _ParseError,
     app_config_from_root,
     convert_from_md_to_pandoc_export,
     default_config,
@@ -229,6 +230,45 @@ SELECT * FROM df;
         assert "SELECT * FROM df;" in notebook_code
         assert result["count"] == 1
 
+    def test_md_class_form_with_space_routes_as_sql(self):
+        """MO-6285: `{sql .marimo}` (md class-form with space) was misclassified as python
+        and silently produced empty output. Should now be normalized to the qmd-form
+        and converted via `sql_to_marimo`."""
+        markdown = """---
+eval: false
+---
+
+```{sql .marimo query="result"}
+SELECT * FROM df;
+```
+"""
+        result = self._convert_without_eval(markdown)
+
+        notebook_code = self._extract_notebook_code(result["header"])
+        assert "result = mo.sql(" in notebook_code
+        assert "SELECT * FROM df;" in notebook_code
+        assert result["count"] == 1
+
+    def test_python_syntax_error_renders_visible_error(self):
+        """MO-6287: cells whose source fails `app.add_code` were silently dropped to
+        an empty HTML node. They should now render a visible <pre class="marimo-error">."""
+        markdown = "```{python .marimo}\ndef bad(:\n```\n"
+        result = convert_from_md_to_pandoc_export(markdown, mime_sensitive=False)
+
+        assert result["count"] == 1
+        value = result["outputs"][0]["value"]
+        assert "marimo-error" in value, f"expected marimo-error block, got: {value!r}"
+        assert "SyntaxError" in value
+
+    def test_python_syntax_error_renders_blockquote_in_pdf(self):
+        """MO-6287, mime-sensitive path: parse errors render as a blockquote, not empty."""
+        markdown = "```{python .marimo}\ndef bad(:\n```\n"
+        result = convert_from_md_to_pandoc_export(markdown, mime_sensitive=True)
+
+        assert result["count"] == 1
+        assert result["outputs"][0]["type"] == "blockquote"
+        assert "SyntaxError" in result["outputs"][0]["value"]
+
 
 class TestGetMimeRender:
     def _make_stub(self, code="x = 1", output=None):
@@ -277,3 +317,32 @@ class TestGetMimeRender:
         result = get_mime_render(global_options, stub, {}, mime_sensitive=False)
         stub.render.assert_called_once()
         assert result["value"] == "<div>output</div>"
+
+    def test_parse_error_renders_visible_pre_in_html(self):
+        result = get_mime_render(
+            {**default_config},
+            _ParseError("SyntaxError: bad"),
+            {},
+            mime_sensitive=False,
+        )
+        assert result["type"] == "html"
+        assert "marimo-error" in result["value"]
+        assert "SyntaxError: bad" in result["value"]
+
+    def test_parse_error_renders_blockquote_when_mime_sensitive(self):
+        result = get_mime_render(
+            {**default_config},
+            _ParseError("boom"),
+            {},
+            mime_sensitive=True,
+        )
+        assert result == {"type": "blockquote", "value": "boom"}
+
+    def test_parse_error_suppressed_when_error_disabled(self):
+        result = get_mime_render(
+            {**default_config},
+            _ParseError("boom"),
+            {"error": False},
+            mime_sensitive=False,
+        )
+        assert result == {"type": "html", "value": ""}


### PR DESCRIPTION
## Summary

Engine followups based on internal audit. Stops failure on parse exception and instead surfaces

## Checklist

- [x] Any AI-generated code has been reviewed line-by-line by the human PR author.
- [x] Tests have been added or updated for the changes (where applicable).
- [x] `make lint` and `make test` pass locally.
- [x] Documentation / tutorials updated where relevant.
