### PR TITLE
ci: run pre-commit on pull requests

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,26 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - run: uvx pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
## What / why

This repo ships a `.pre-commit-config.yaml`, but nothing was actually running it: **pre-commit.ci is not installed on this repo**, and no CI workflow invoked the hooks. That means contributors without local pre-commit installed silently bypass trailing-whitespace/EOF, YAML, and ruff (lint + format) checks — the config was dead weight.

This adds a `pre-commit` GitHub Actions workflow that runs the existing hooks on every pull request (and on pushes to `main`), so the config is actually enforced.

## The workflow

- Runs `uvx pre-commit run --all-files --show-diff-on-failure` via `astral-sh/setup-uv`.
- Read-only (`permissions: contents: read`) — it reports failures with a diff rather than auto-pushing fixes.
- Caches `~/.cache/pre-commit` keyed on the config hash.
- All actions are SHA-pinned, matching this repo's existing workflow pin style.

## Autofixes included

None — running `pre-commit run --all-files` on `main` passes cleanly today:

```
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...............................................................Passed
check for merge conflicts................................................Passed
ruff.....................................................................Passed
ruff-format..............................................................Passed
```

Part of the marimo-team engineering-excellence initiative to make sure every repo's declared quality gates actually run in CI.