### PR TITLE
release: v0.5.0

### DIFF
--- a/_extensions/marimo/_extension.yml
+++ b/_extensions/marimo/_extension.yml
@@ -1,5 +1,5 @@
 title: Quarto Marimo Extension
-version: 0.4.5
+version: 0.5.0
 quarto-required: ">=1.9.20"
 contributes:
   engines:

--- a/_extensions/marimo/python/extract.py
+++ b/_extensions/marimo/python/extract.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from quarto_marimo.cli import main
 
-__version__ = "0.4.5"
+__version__ = "0.5.0"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Bumps quarto-marimo to 0.5.0 so the retained-island loader and its GitHub release use the same version. The tagged build publishes `marimo-engine-v0.5.0.js`, `browser-v0.5.0.js`, and `islands-bridge-v0.5.0.css`.

After the stack merges, we'll need to tag this release commit as `v0.5.0` to publish the assets used by fresh extension installs.