### PR TITLE
fix(setup): normalize Quarto archive layouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ ENGINE_CACHE := _extensions/marimo/marimo-engine-v$(VERSION).js
 
 QUARTO_VERSION ?= 1.9.37
 QUARTO_DIR := .quarto-dev/$(QUARTO_VERSION)
+QUARTO_DOWNLOAD_URL ?= https://github.com/quarto-dev/quarto-cli/releases/download/v$(QUARTO_VERSION)/$(QUARTO_PKG)
 
 ifeq ($(shell uname -s),Darwin)
   QUARTO_PKG := quarto-$(QUARTO_VERSION)-macos.tar.gz
@@ -32,12 +33,26 @@ else
   PYTEST := uv run --with pytest pytest
 endif
 
+# macOS archives are flat. Linux archives wrap the tree in a versioned directory.
 $(QUARTO_DIR)/bin/quarto:
-	mkdir -p $(QUARTO_DIR)
-	curl -fSL -o /tmp/$(QUARTO_PKG) \
-		https://github.com/quarto-dev/quarto-cli/releases/download/v$(QUARTO_VERSION)/$(QUARTO_PKG)
-	tar xzf /tmp/$(QUARTO_PKG) -C $(QUARTO_DIR)
-	rm /tmp/$(QUARTO_PKG)
+	@set -eu; \
+	stage=$$(mktemp -d); \
+	trap 'rm -rf "$$stage"' EXIT; \
+	archive="$$stage/$(QUARTO_PKG)"; \
+	unpacked="$$stage/unpacked"; \
+	mkdir -p "$$unpacked"; \
+	curl -fSL -o "$$archive" "$(QUARTO_DOWNLOAD_URL)"; \
+	tar xzf "$$archive" -C "$$unpacked"; \
+	if [ -x "$$unpacked/bin/quarto" ]; then \
+		root="$$unpacked"; \
+	elif [ -x "$$unpacked/quarto-$(QUARTO_VERSION)/bin/quarto" ]; then \
+		root="$$unpacked/quarto-$(QUARTO_VERSION)"; \
+	else \
+		echo "Unsupported Quarto archive layout: missing bin/quarto" >&2; \
+		exit 1; \
+	fi; \
+	mkdir -p "$(QUARTO_DIR)"; \
+	cp -R "$$root/." "$(QUARTO_DIR)"
 
 setup: $(QUARTO_DIR)/bin/quarto
 

--- a/tests/python/test_setup.py
+++ b/tests/python/test_setup.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize(
+    ("archive_root", "marker"),
+    [("", "flat"), ("quarto-1.9.37", "nested")],
+)
+def test_setup_normalizes_quarto_archive_layout(
+    tmp_path: Path,
+    archive_root: str,
+    marker: str,
+) -> None:
+    source = tmp_path / "source" / archive_root / "bin"
+    source.mkdir(parents=True)
+    quarto = source / "quarto"
+    quarto.write_text(f"#!/bin/sh\necho {marker}\n", encoding="utf-8")
+    quarto.chmod(0o755)
+
+    archive = tmp_path / "quarto-fixture.tar.gz"
+    with tarfile.open(archive, "w:gz") as bundle:
+        bundle.add(tmp_path / "source", arcname=".")
+
+    install = tmp_path / "install"
+    subprocess.run(
+        [
+            "make",
+            f"QUARTO_DIR={install}",
+            "QUARTO_PKG=quarto-fixture.tar.gz",
+            f"QUARTO_DOWNLOAD_URL={archive.as_uri()}",
+            "setup",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    installed = install / "bin" / "quarto"
+    assert installed.read_text(encoding="utf-8") == quarto.read_text(encoding="utf-8")
+    assert os.access(installed, os.X_OK)


### PR DESCRIPTION
## Summary

- stage Quarto downloads in a unique temporary directory
- normalize flat macOS and version-wrapped Linux archives to the same install path
- reject unknown archive layouts before copying files
- add regression coverage for both supported layouts

## Testing

- nix shell nixpkgs#pixi nixpkgs#gnumake -c pixi run lint
- nix shell nixpkgs#pixi nixpkgs#gnumake -c pixi run test
- nix shell nixpkgs#pixi nixpkgs#gnumake -c pixi run render
- focused flat and nested archive fixture tests