### PR TITLE
fix(engine): honor QUARTO_PYTHON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ Quarto engine types, Pandoc output, or Quarto theme classes.
 
 | Variable | Behavior |
 | --- | --- |
+| `QUARTO_PYTHON` | Select the Python executable used by `external-env: true`. Defaults to `python` on `PATH`. |
 | `QUARTO_MARIMO_VERSION` | Select the marimo runtime version compiled into interactive output. Use it to bisect runtime regressions. |
 | `QUARTO_MARIMO_DEBUG_ENDPOINT` | Load marimo runtime assets from an absolute development server URL. |
 | `QUARTO_MARIMO_TIMEOUT_SECONDS` | Set the compiler subprocess timeout. The default is 300 seconds. |

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ pyproject: |
 ```
 
 Set `external-env: true` to execute with the active Python environment during
-the Quarto build.
+the Quarto build. Set `QUARTO_PYTHON` to choose its Python executable. It
+defaults to `python` on `PATH`.
 
 Set `header` to Python source that runs as a setup cell before the authored
 cells:

--- a/src/engine/process.ts
+++ b/src/engine/process.ts
@@ -39,7 +39,7 @@ export async function runMarimoCompiler(
   let temporaryDirectory: string | undefined;
 
   if (options.externalEnv) {
-    command = "python";
+    command = Deno.env.get("QUARTO_PYTHON") ?? "python";
     args = [extractPath];
   } else {
     command = "uv";

--- a/src/engine/process.ts
+++ b/src/engine/process.ts
@@ -39,7 +39,7 @@ export async function runMarimoCompiler(
   let temporaryDirectory: string | undefined;
 
   if (options.externalEnv) {
-    command = Deno.env.get("QUARTO_PYTHON") ?? "python";
+    command = Deno.env.get("QUARTO_PYTHON") || "python";
     args = [extractPath];
   } else {
     command = "uv";

--- a/tests/engine/process.test.ts
+++ b/tests/engine/process.test.ts
@@ -1,8 +1,47 @@
-import { assertRejects } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 
 import type { QuartoAPI } from "@quarto/types";
 
-import { executeProcess } from "../../src/engine/process.ts";
+import { executeProcess, runMarimoCompiler } from "../../src/engine/process.ts";
+
+Deno.test({
+  name: "external environments use QUARTO_PYTHON",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const command = await Deno.makeTempFile();
+    const previous = Deno.env.get("QUARTO_PYTHON");
+    try {
+      await Deno.writeTextFile(
+        command,
+        '#!/bin/sh\nprintf \'%s\\n\' \'{"kind":"static","outputs":[]}\'\n',
+      );
+      await Deno.chmod(command, 0o755);
+      Deno.env.set("QUARTO_PYTHON", command);
+
+      const quarto = {
+        console: { info: () => {} },
+      } as unknown as QuartoAPI;
+      const result = await runMarimoCompiler(quarto, {
+        moduleUrl: import.meta.url,
+        source: "",
+        input: "page.qmd",
+        interactive: false,
+        globalEval: true,
+        externalEnv: true,
+        pyproject: "",
+      });
+
+      assertEquals(result, { kind: "static", outputs: [] });
+    } finally {
+      if (previous === undefined) {
+        Deno.env.delete("QUARTO_PYTHON");
+      } else {
+        Deno.env.set("QUARTO_PYTHON", previous);
+      }
+      await Deno.remove(command);
+    }
+  },
+});
 
 Deno.test("compiler processes stop at the configured timeout", async () => {
   const quarto = {


### PR DESCRIPTION
Use QUARTO_PYTHON as the compiler executable when a document sets external-env: true. Fall back to python on PATH when the variable is unset.

Add an integration test that launches the compiler through a temporary executable, and document the setting in README.md and AGENTS.md.

This addresses the interpreter-selection part of #91. The remaining session-mode, socket, failure-propagation, and dotenv requests stay open.

Validation:
- pixi run lint
- pixi run test (16 TypeScript, 52 Python)
- pixi run render (14 documentation pages, including PDF)